### PR TITLE
use xxhash instead of md5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,6 +729,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "uuid",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -1533,3 +1534,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "1.0.51"
 tikv-jemallocator = { version = "0.5.4", optional = true }
 tokio = { version = "1.35.0", features = ["rt-multi-thread", "fs", "macros"] }
 uuid = { version = "1.6.1", features = ["v4"] }
+xxhash-rust = { version = "0.8.8", features = ["xxh64", "xxh3"] }
 
 [dev-dependencies]
 criterion = "0.5.1"
@@ -44,4 +45,8 @@ path = "src/lib.rs"
 
 [[bench]]
 name = "md5"
+harness = false
+
+[[bench]]
+name = "xxhash"
 harness = false

--- a/benches/md5.rs
+++ b/benches/md5.rs
@@ -23,8 +23,7 @@ fn md5_file(c: &mut Criterion) {
     });
 }
 
-// criterion_group!(md5, md5_contents, md5_file);
-criterion_group!(md5, md5_file);
+criterion_group!(md5, md5_contents, md5_file);
 // criterion_main!(md5);
 
 fn main() {

--- a/benches/xxhash.rs
+++ b/benches/xxhash.rs
@@ -1,0 +1,23 @@
+use std::fs;
+
+use criterion::{black_box, criterion_main, criterion_group, Criterion};
+
+use mtl::hash;
+
+fn xxh3_contents(c: &mut Criterion) {
+    let contents = fs::read("/usr/share/dict/words").unwrap();
+    c.bench_function("xxh3_contents", |b| {
+        b.iter(|| hash::xxh3_contents(black_box(&contents)))
+    });
+}
+
+fn xxh64_contents(c: &mut Criterion) {
+    let contents = fs::read("/usr/share/dict/words").unwrap();
+    c.bench_function("xxh64_contents", |b| {
+        b.iter(|| hash::xxh64_contents(black_box(&contents)))
+    });
+}
+
+
+criterion_group!(xxhash, xxh3_contents, xxh64_contents);
+criterion_main!(xxhash);

--- a/src/bin/xxhash.rs
+++ b/src/bin/xxhash.rs
@@ -1,0 +1,15 @@
+use std::io;
+use std::io::Read;
+use mtl::hash;
+
+fn main() -> io::Result<()> {
+    let stdin = io::stdin();
+    let mut input = stdin.lock();
+
+    let mut line = String::new();
+    input.read_to_string(&mut line)?;
+
+    println!("xxh64: {:x}", hash::xxh64_contents(&line));
+    println!("xxh3 : {:x}", hash::xxh3_contents(&line));
+    Ok(())
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -59,7 +59,7 @@ impl PrintTreeCommand {
             Some(ref object_id) => object_id.clone(),
             None => {
                 let head = fs::read_to_string(ref_head_name())?;
-                ObjectID::from_hex(&head)?
+                ObjectID::from_hex(&head).unwrap()
             }
         };
         let object_type = self.r#type.as_ref();

--- a/tools/build-by-revision.sh
+++ b/tools/build-by-revision.sh
@@ -30,7 +30,7 @@ fi
 revision=$1
 params=${2:-""}
 hash=$(git rev-parse --short $revision)
-tmp_branch=$(head /dev/urandom | md5)
+tmp_branch=$(head /dev/urandom | openssl dgst -sha1 --binary | xxd -p)
 
 
 echo "Building revision $revision($hash)..."


### PR DESCRIPTION

```bash
mtl on  xxhash-not-md5 is 📦 v0.1.0 🦀 v1.74.1 ☁️  (tokyo) ☁️  (ycmm-admin)
λ ./tools/compare-performance.sh /tmp/bench10000/ xxhash-not-md5 main '--warmup 3'
Comparing xxhash-not-md5(1e16b2d) and main(a120283)

Benchmark 1: /Users/taisuke/source/mtl/target/release/mtl-1e16b2d local build -c /tmp/bench10000/
  Time (mean ± σ):     290.8 ms ±   9.7 ms    [User: 257.1 ms, System: 1109.7 ms]
  Range (min … max):   280.7 ms … 308.4 ms    10 runs

Benchmark 2: /Users/taisuke/source/mtl/target/release/mtl-a120283 local build -c /tmp/bench10000/
  Time (mean ± σ):     621.0 ms ±  22.4 ms    [User: 2355.6 ms, System: 1121.4 ms]
  Range (min … max):   597.7 ms … 657.8 ms    10 runs

Summary
  /Users/taisuke/source/mtl/target/release/mtl-1e16b2d local build -c /tmp/bench10000/ ran
    2.14 ± 0.11 times faster than /Users/taisuke/source/mtl/target/release/mtl-a120283 local build -c /tmp/bench10000/

```